### PR TITLE
Migrate Cloud Functions calls to v2 HTTP endpoints (Python backend)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,44 +1,31 @@
-## Getting started
-Install angular-cli : https://cli.angular.io/
+## RedQuest
 
-Run `npm install`
+Angular 10 front-end + Firebase (Firestore + Cloud Functions).
 
-Enjoy
+## Prerequisites
 
-## GCloud setup
+### Tooling
 
-### Install command line tools
+- Node.js + npm (deployment script expects Node 14 available at `/usr/local/opt/node@14/bin`).
+- Angular CLI: `npm install -g @angular/cli`
+- Firebase CLI: `npm install -g firebase-tools`
+- Google Cloud SDK (gcloud): https://cloud.google.com/sdk/docs/install
 
-Install gcloud sdk
+### Google Cloud / Firebase access
 
-see : https://cloud.google.com/sdk/docs/downloads-interactive
+- Your account must be granted access to the target project (IAM owner/editor).
+- Login to gcloud and firebase:
+  - `gcloud init`
+  - `firebase login`
 
-Install firebase tools
+## Install
 
-`npm install -g firebase-tools`
+`npm install`
 
-### Setup rights in Google Cloud Platform with IAM
+## Environments
 
-Add the gmail or GSuite account as project owner
-
-### Login & set default project
-
-Login :
-`gcloud init`
-use the gmail account (or gsuite account) that was used in the previous chapter
-
-Set the correct project : 
-`gcloud config set project rq-fr-dev`
-
-
-# RedQuest
-
-This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 7.0.5.
-
-## Start a server
-### Prepare environments
-
-Get the environment files from the Google Drive (ask a developer) and put them at `/src/environments/`. Once done you should have : 
+Environment files are not in git. Get them from Google Drive (ask a dev) and place them in `src/environments/`.
+You should have:
 ```bash
 $ ls src/environments/
 environment.dev.ts
@@ -48,20 +35,19 @@ environment.test.ts
 environment.ts
 ```
 
-
-
-### Development server:
+## Start a server
+### Development server
 
 * Run `ng build --configuration dev` to prepare the server with *dev* environment settings.
 * Then run `ng serve --configuration dev` for a dev server. 
 
 
-### Test server:
+### Test server
 
 * Run `ng build --configuration test` to prepare the server with *test* environment settings.
 * Then run `ng serve --configuration test` for a test server.
 
-### Production server:
+### Production server
 ```diff
 - CAUTION: do not use this environment, unless someone asked you to use it !
 ```
@@ -97,22 +83,34 @@ Run `ng e2e` to execute the end-to-end tests via [Protractor](http://www.protrac
 To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI README](https://github.com/angular/angular-cli/blob/master/README.md).
 
 
-## To deploy with firebase
+## Deploy
 
-install firebase tools:
+### One-command deploy
 
-`npm install -g firebase-tools`
+The repo ships a helper script:
+```bash
+./gcp-deploy.sh fr dev
+./gcp-deploy.sh fr test
+./gcp-deploy.sh fr prod
+```
 
-`firebase login`
+This script:
+- Sets the target GCP project (`rq-fr-{env}`)
+- Runs `firebase use --add`
+- Builds Angular (`ng build`)
+- Runs `firebase deploy`
 
-To test authentication:
+Requirements: `gcloud`, `firebase` and `ng` must be in your PATH.
 
-`firebase projects:list`
+### Manual deploy
 
-`firebase use --add {project-id}`
+```bash
+ng build --configuration dev   # or test/prod
+firebase deploy
+```
 
+### Troubleshooting
 
-To deploy project:
-
-run `ng build --prod` to generate sources to be deployed
-run `firebase deploy` and follow instructions
+- If you see `firebase: command not found` or `ng: command not found`, install:
+  - `npm install -g firebase-tools @angular/cli`
+- `gcp-deploy.sh` prepends `/usr/local/opt/node@14/bin` to PATH. If you don’t have Node 14 installed there, either install it or edit the script to match your local setup.

--- a/docs/cloud-functions-endpoints.md
+++ b/docs/cloud-functions-endpoints.md
@@ -1,0 +1,168 @@
+# Configuration des endpoints Cloud Functions
+
+Document d'analyse et de planification — migration des Cloud Functions GCP v1 (NodeJS) vers v2 (Python).
+
+## 0. TL;DR — Décision
+
+- **Cible serveur** (figée par le projet `rcq-functions-v2`) : 9 Cloud Functions HTTPS Gen2 Python `on_request`, hébergées sur le projet `rq-fr-<env>` en région `europe-west1`, avec vérification du Firebase ID Token via header `Authorization: Bearer <id_token>` côté handler (helper `rcq_common.auth_firebase`).
+- **Décision côté client (Option B)** : remplacer les appels Callable (`AngularFireFunctions.httpsCallable`) par des appels **HTTP** standards (`HttpClient`) avec injection automatique du Bearer token via un `HttpInterceptor`. Justification détaillée en §6.
+- **Impact env** : seul renommage `getULPrefs` → `get-ul-prefs` et `getULStats` → `get-ul-stats` (déjà appliqué à `environment.dev.ts`). Base URL et région inchangées.
+- **Impact code** : refonte de `CloudFunctionService` + ajout d'un `AuthTokenInterceptor` + suppression de la dépendance à `AngularFireFunctionsModule`. Voir le plan en §7.
+
+---
+
+## 1. Inventaire des endpoints v2 utilisés par RedQuest
+
+Source : lecture directe des handlers `functions/*/main.py` du dépôt `rcq-functions-v2` (Phase A1/A2). Les 9 fonctions appelées par RedQuest sont toutes des **HTTP Gen2 Flask** (`def main(request: Request)`, déployées avec `--trigger-http --allow-unauthenticated`), hébergées sur `rq-fr-<env>`, région `europe-west1`. L'auth applicative est gérée dans le handler par `rcq_common.auth_firebase.verify_request` qui exige `Authorization: Bearer <Firebase ID Token>` et vérifie le claim `aud == FIREBASE_PROJECT_ID`.
+
+> Toutes les fonctions répondent **204** sur `OPTIONS` (preflight CORS) et reflètent l'`Origin` de la requête dans `Access-Control-Allow-Origin` → toute origine est accept​ée (cf. §A5).
+
+| Clé `cloudFunctionsNames` | Endpoint v2 | Méthode HTTP recommandée | Auth | Entrée | Sortie | Codes erreur |
+|---|---|---|---|---|---|---|
+| `findQueteurById` | `find-queteur-by-id` | `GET` (handler ne lit ni body ni query) | Bearer | — (UID extrait du token, mappage `ul_id`/`queteur_id` lu dans Firestore) | `Queteur` JSON aplati (`id`, `email`, `first_name`, …, `ul_*`) | 401 unauthorized · 400 missing identifiers · 404 not found · 500 db error |
+| `findULDetailsByToken` | `find-ul-details-by-token` | `GET ?token=<uuid>` | **Aucune** (pas de `verify_request`) | query `token` (UUID 36 chars, 4 tirets) | `ULDetails` JSON ou `[]` si non trouvé | 400 invalid token · 500 db error |
+| `getULPrefs` | `get-ul-prefs` | `GET` | Bearer | — | `ULPrefs` JSON (clés `rq_display_*`, `rq_autonomous_*`, `ul_id`) ; **defaults** renvoyés si non trouvé (200 quand même) | 401 · 400 missing/invalid `ul_id` · 500 firestore error |
+| `getULStats` | `get-ul-stats` | `GET` | Bearer | — | `ULStats` JSON ; **`null`** (200) si pas de stats | 401 · 400 missing/invalid `ul_id` · 500 firestore error |
+| `historiqueTroncQueteur` | `historique-tronc-queteur` | `GET` | Bearer | — | `HistoriqueTroncQueteur[]` (cache Firestore TTL 5 min ; renvoie tableau d'objets MySQL avec colonnes `depart_theorique`, `depart`, `retour`, `amount`, `weight`, …) | 401 · 400 missing identifiers · 404 queteur not found · 500 db error |
+| `registerQueteur` | `register-queteur` | `POST` JSON | Bearer | JSON `Queteur` avec champs requis : `first_name, last_name, man, birthdate, email, secteur, nivol, mobile, ul_registration_token, benevole_referent` | **JSON natif** : `{ "queteur_registration_token": "<uuid>" }` ⚠ Plus de `JSON.parse` ! | 401 · 400 missing fields · 500 db error |
+| `troncListPrepared` | `tronc-list-prepared` | `GET` | Bearer | — | Tableau d'objets : `tronc_queteur_id, queteur_id, point_quete_id, tronc_id, depart_theorique` (ISO string), `depart` (ISO string ou null), `name, latitude, longitude, address, postal_code, city, advice, localization` | 401 · 400 missing identifiers · 404 · 500 |
+| `troncSetDepartOrRetour` | `tronc-set-depart-or-retour` | `POST` JSON | Bearer | `{ isDepart: boolean, date: string ISO, tqId: number }` | `{ "success": true }` | 401 · 400 missing fields · 404 · 500 incorrect rows |
+| `resyncQueteurIdToFirestore` | `resync-queteur-id-to-firestore` | `GET` (pas de body lu) | Bearer | — | `{ "updated": <int> }` | 401 · 500 |
+
+**Base URL** : `https://europe-west1-rq-fr-<env>.cloudfunctions.net/` (alias Gen1 conservé par Gen2 — confirmé par `function_triggers.py` qui déploie en `--gen2` sans config d'URL custom).
+
+**Autres fonctions v2 non appelées par RedQuest** : `compute-ul-tasks`, `notify-rq-of-regist-approval`, `ul-trigger-recompute`, `ul-queteur-stats-per-year`, `ztest-*`.
+
+## 2. Configuration côté client — état après migration
+
+### 2.1 `src/environments/environment.{dev,test,prod}.ts`
+
+```typescript
+cloudFunctionsBaseUrl: 'https://europe-west1-rq-fr-<env>.cloudfunctions.net/',
+cloudFunctionsNames: {
+  findQueteurById:            'find-queteur-by-id',
+  findULDetailsByToken:       'find-ul-details-by-token',
+  troncSetDepartOrRetour:     'tronc-set-depart-or-retour',
+  registerQueteur:            'register-queteur',
+  troncListPrepared:          'tronc-list-prepared',
+  resyncQueteurIdToFirestore: 'resync-queteur-id-to-firestore',
+  historiqueTroncQueteur:     'historique-tronc-queteur',
+  getULPrefs:                 'get-ul-prefs',  // ⚠ renommé depuis 'getULPrefs'
+  getULStats:                 'get-ul-stats'   // ⚠ renommé depuis 'getULStats'
+},
+```
+
+- `dev` : déjà mis à jour ✅
+- `test`, `prod` : à appliquer (voir tâches §7).
+
+### 2.2 `src/app/app.module.ts`
+
+- Token `REGION` (`europe-west1`) : **conservé** tant que `AngularFireFunctionsModule` reste importé pour ne pas casser une éventuelle utilisation indirecte. Sera supprimé en fin de migration (cf. §7).
+- `AngularFireFunctionsModule` : **à retirer** une fois `CloudFunctionService` migré et qu'aucun autre module ne l'utilise.
+
+## 3. Point d'utilisation unique côté client
+
+📁 `src/app/services/cloud-functions/cloud-function.service.ts` — seul consommateur des noms et de l'URL de base. C'est le fichier à refondre intégralement.
+
+## 4. Consommateurs (callers) de `CloudFunctionService` — à retester après migration
+
+Recensement exhaustif Phase A3 (`grep` sur `src/app/`).
+
+| Méthode service | Fichiers appelants |
+|---|---|
+| `findQueteurById$` | `services/queteur/queteur.service.ts` (commenté, non actif) |
+| `findULDetailsByToken$` | `modules/registration/registration.component.ts` · `modules/registration/registration-confirmation/registration-confirmation.component.ts` · `modules/account/account.component.ts` · `components/local-unit/local-unit.component.ts` |
+| `getULPrefs$` | `app.component.ts` · `components/homepage/homepage.component.ts` · `components/ranking/ranking.component.ts` · `modules/quest/my-slots/my-slots.component.ts` |
+| `getULStats$` | `components/homepage/homepage.component.ts` |
+| `registerQueteur$` | `modules/registration/registration-step-2/registration-step-2.component.ts` |
+| `retrievePreparedTroncs$` | `modules/quest/my-slots/my-slots.component.ts` |
+| `troncStateUpdate$` | `modules/quest/my-slots/my-slots.component.ts` (×2 : départ + retour) |
+| `historiqueTroncQueteur$` | `modules/quest/queteur-history/queteur-history.component.ts` |
+| `resyncQueteurIdToFirestore$` | **Aucun appelant** côté Angular (méthode présente dans `cloudFunctionsNames` mais pas exposée par `CloudFunctionService`) → ne pas implémenter dans la refonte. |
+
+> Détail intéressant : `findULDetailsByToken$` est appelée depuis **4 endroits dont 2 dans des contextes authentifiés** (`account` et `local-unit` — utilisateur connecté) et 2 dans le flux de registration (potentiellement non-connecté). Côté serveur, la fonction v2 **n'exige pas d'auth** (cf. §1) → ne pas inclure cette URL dans le filtre de l'`AuthTokenInterceptor`, ou laisser l'interceptor injecter le token quand il est disponible (sans bloquer si absent). Voir §8.1 (résolu).
+
+## 5. Comparatif Callable (`on_call`) vs HTTP brut (`on_request`)
+
+| Aspect | Callable (`httpsCallable`) | HTTP brut (Bearer header) — **cible** |
+|---|---|---|
+| Wire-format requête | `POST` body `{"data": <payload>}` | `GET`/`POST` JSON natif |
+| Wire-format réponse | `{"result": <payload>}` (extrait par le SDK) | JSON natif |
+| Auth | Token injecté automatiquement par le SDK | `Authorization: Bearer <id_token>` injecté par interceptor |
+| CORS | Géré côté runtime Firebase | Géré par le handler (chaque fonction reflète l'`Origin` de la requête → toute origine accept​ée) |
+| Erreurs | `FirebaseError` typées | Status HTTP + body JSON `{ "error": "<message>" }` |
+| Testabilité externe (curl/Postman) | Difficile (wire-format propriétaire) | Triviale |
+| Couplage SDK Firebase | Fort | Faible (juste pour récupérer le ID token) |
+
+## 6. Décision — Option B (HTTP)
+
+Choix retenu : **client HTTP brut + Bearer token**, pour les raisons suivantes :
+
+1. **Cohérence avec l'architecture v2** : 14/15 fonctions Gen2 sont `on_request` avec auth Bearer (`rcq_common.auth_firebase`). Conserver des Callables côté Angular obligerait à maintenir deux protocoles serveur.
+2. **Multi-consommateurs** : un backend PHP RedQuest existe déjà dans l'écosystème (publish Pub/Sub). Le HTTP brut reste appelable depuis n'importe quel client (PHP, scripts, mobile, webhooks) ; la Callable est captive du SDK Firebase.
+3. **Découplage SDK** : `@angular/fire` v6 / `firebase` v8 sont dépréciés. Une montée à `@angular/fire` v7+ change l'API Callable. Le HTTP brut reste stable face à ces évolutions.
+4. **Sémantique HTTP** : codes status exploitables (`401`, `403`, `404`, `429`, `5xx`), méthodes appropriées (`GET` cacheable), traçabilité Cloud Run native.
+5. **Testabilité** : `curl`, Postman, Insomnia, intégration tests E2E sans dépendance Firebase.
+6. **Effort localisé** : la refonte se concentre sur **un seul fichier service** + un interceptor partagé. Les composants appelants ne changent pas (mêmes signatures `Observable<T>`).
+
+## 7. Plan d'implémentation (haut niveau)
+
+> Détail opérationnel suivi dans la task list de la conversation. Les tâches sont ordonnées et chacune doit pouvoir être livrée indépendamment (PR atomique recommandée si possible, sinon une seule PR avec commits séparés).
+
+### Phase A — Préparation (sans modification fonctionnelle)
+1. **Vérifier côté serveur** : confirmer que toutes les fonctions cibles sont bien `@https_fn.on_request` (pas `on_call`) en lisant le code Python de `rcq-functions-v2`.
+2. **Documenter les contrats** : pour chaque fonction, relever en code Python : méthode HTTP, format du body d'entrée, format du body de sortie, codes d'erreur. Compléter le tableau §1.
+3. **Recenser les appelants** : `grep` exhaustif des 9 méthodes de `CloudFunctionService` dans `src/app/` pour valider la liste §4.
+
+### Phase B — Plomberie HTTP authentifiée
+4. **Créer `AuthTokenInterceptor`** (`src/app/services/auth/auth-token.interceptor.ts`) :
+   - injecte `AngularFireAuth`,
+   - intercepte uniquement les requêtes vers `environment.cloudFunctionsBaseUrl`,
+   - récupère le ID token via `angularFireAuth.idToken` (Observable) ou `angularFireAuth.currentUser.then(u => u.getIdToken())`,
+   - ajoute le header `Authorization: Bearer <token>`,
+   - laisse passer les requêtes vers d'autres origines sans modification.
+5. **Enregistrer l'interceptor** dans `app.module.ts` via `HTTP_INTERCEPTORS` (multi-provider).
+6. **Tests unitaires de l'interceptor** : cas connecté, cas anonyme, cas URL externe.
+
+### Phase C — Refonte du service
+7. **Réécrire `CloudFunctionService`** :
+   - supprimer la dépendance à `AngularFireFunctions`,
+   - chaque méthode → `this.http.get/post<T>(url, body?)` retournant `Observable<T>`,
+   - conserver les **signatures publiques** (mêmes noms, mêmes types de retour) pour ne rien casser côté composants,
+   - retirer les `JSON.parse(value)` inutiles (le serveur Python renverra du JSON déjà parsé par `HttpClient`),
+   - conserver le reviver de dates pour `retrievePreparedTroncs$` (transformer via `map(...)` après `http.get`).
+8. **Mettre à jour le test** `cloud-function-service.service.spec.ts` (TestBed avec `HttpClientTestingModule`).
+9. **Supprimer `AngularFireFunctionsModule`** de `app.module.ts` et le provider `REGION` si plus aucun consommateur.
+
+### Phase D — Validation E2E
+10. **Mettre à jour `environment.test.ts` et `environment.prod.ts`** (renommage `getULPrefs`/`getULStats` + base URL `rq-fr-test` / `rq-fr-prod`).
+11. **Tester chaque flux fonctionnel** contre l'env `dev` :
+    - login Firebase → vérifier que le token est bien injecté (DevTools → Network → header `Authorization`),
+    - homepage : `get-ul-prefs` + `get-ul-stats`,
+    - registration via lien email : `find-ul-details-by-token` puis `register-queteur` (cf. §8),
+    - module quest : `tronc-list-prepared`, `tronc-set-depart-or-retour`, `historique-tronc-queteur`,
+    - resync : `resync-queteur-id-to-firestore` (si déclenchable depuis l'UI).
+12. **Vérifier les codes erreur** : un 401 (token expiré) doit déclencher une redirection login propre — éventuellement ajouter un `HttpErrorInterceptor` dédié si besoin.
+
+## 8. Points d'attention / questions ouvertes
+
+1. **`find-ul-details-by-token` et flux registration non authentifié** — ✅ **RÉSOLU Phase A1** : le handler Python **n'appelle pas** `verify_request()` ; seule la validité formelle du paramètre `?token=<uuid>` (36 chars, 4 tirets) est contrôlée. La fonction est donc **publique** et compatible avec un appel anonyme depuis l'écran de registration. → L'`AuthTokenInterceptor` doit traiter cet endpoint en mode "best-effort" (injecter le token uniquement s'il est disponible, ne jamais bloquer la requête).
+2. **`registerQueteur$.pipe(map(value => JSON.parse(value)))`** — ✅ **CONFIRMÉ Phase A2** : le handler Python renvoie un JSON natif `{"queteur_registration_token": "<uuid>"}` (Content-Type `application/json`). Le `JSON.parse` côté Angular doit être **supprimé** dans la refonte (`HttpClient` désérialise automatiquement).
+3. **`retrievePreparedTroncs$` reviver de dates** — ⚠️ **À CORRIGER Phase C** : le code Angular actuel cherche un champ `arrivee`, mais le handler Python ne renvoie que `depart_theorique`, `depart` (et n'a **pas** de champ `arrivee` ni `retour` dans cette query). À adapter dans le `map` post-`http.get` pour ne parser que les champs réellement présents (`depart_theorique`, `depart`).
+4. **`historique-tronc-queteur` et dates** — ℹ️ La query SQL retourne `depart_theorique`, `depart`, `retour` au format ISO string. Le code Angular actuel ne fait pas de reviver de dates sur cette réponse — à laisser tel quel sauf si un consommateur en aval exige des `Date`.
+5. **CORS** — ✅ **VÉRIFIÉ Phase A5** : chaque handler reflète l'`Origin` reçu dans `Access-Control-Allow-Origin` (pas d'allowlist statique côté v2). Toutes les origines RedQuest (`localhost:4200`, `*.web.app`, `*.firebaseapp.com`) seront acceptées sans configuration supplémentaire.
+6. **`firebase.json` rewrites** — Aucun rewrite `/api/**` n'existe actuellement vers les Cloud Functions ; les appels resteront cross-origin directs vers `cloudfunctions.net` (cohérent avec le reflet d'`Origin` côté v2). Pas de changement requis.
+7. **Token refresh** — `AngularFireAuth.currentUser.then(u => u.getIdToken(false))` retourne le token courant (rafraîchi automatiquement si expiré dans <5 min). C'est le pattern à utiliser dans l'interceptor (Phase B1).
+8. **Codes erreur** — Tous les handlers v2 renvoient `{ "error": "<message>" }` avec un status HTTP 4xx/5xx approprié. Un 401 (token expiré/invalide) doit déclencher une redirection login propre — à traiter dans un `HttpErrorInterceptor` complémentaire si besoin (hors scope migration immédiate).
+
+## 9. Régression & rollback
+
+- Migration intégralement côté client → rollback = `git revert` du commit (pas de migration de schéma serveur impliquée).
+- Les fonctions v1 NodeJS et v2 Python peuvent **co-exister** transitoirement sous le même nom si elles sont déployées sur des projets distincts ; bascule contrôlée par la valeur de `cloudFunctionsBaseUrl` dans l'environnement Angular.
+
+## 10. Correctifs annexes inclus dans la migration
+
+| Fichier | Problème pré-existant | Correctif appliqué | Justification |
+|---|---|---|---|
+| `src/app/modules/account/account.component.spec.ts` | Le fichier importait `RegistrationConfirmationComponent` depuis `./registration-confirmation.component` (chemin inexistant dans le dossier `account/`) → erreur TS2307 bloquant la compilation de **toute la suite Karma**. Présent depuis le commit `9857512`. | Remplacé par un test stub minimal alignée sur le pattern du projet (cf. `auth.service.spec.ts`, `firestore.service.spec.ts`) : import + `expect(AccountComponent).toBeTruthy()`. | Sans ce fix, Phase B3 (tests unitaires de l'interceptor) ne peut pas être exécutée via `ng test`. Correctif minimal, périmètre 1 fichier, sans impact fonctionnel. |
+

--- a/docs/security-audit-framework.md
+++ b/docs/security-audit-framework.md
@@ -1,0 +1,218 @@
+# Audit sécurité — supply chain + hardening classique
+
+Ce document est un **prompt prêt à coller** pour lancer un audit sécurité complet sur un projet logiciel. Il couvre deux volets : attaques supply chain (npm/PyPI/GitHub Actions, y compris les compromissions récentes Shai-Hulud, nx, chalk/Qix, tj-actions, xz-utils) et hardening classique (auth, secrets, CORS, headers, injection, autorisation, CI/CD).
+
+**Comment l'utiliser** : créer un nouveau workspace Intent sur le repo cible, coller ce fichier (ou son contenu) au coordinator, remplir les 3 placeholders du bloc « Contexte projet », puis laisser le coordinator faire la phase Recon et planifier les waves. Le coordinator ne code pas lui-même : il délègue à des implementors et fait vérifier par des verifiers.
+
+---
+
+## Contexte projet
+- **Repo** : <chemin local ou URL git>
+- **Stack** : <ex: Node/Angular + Python/FastAPI + MySQL, ou autre — laisse vide pour auto-détection>
+- **Environnements** : <local, dev, test, prod — décris brièvement comment ils sont déployés>
+
+## Objectif
+Faire un audit sécurité complet en deux volets :
+1. **Supply chain** — détecter et corriger toute dépendance compromise, obsolète ou vulnérable, et durcir l'intégrité des lockfiles.
+2. **Hardening classique** — corriger les vulnérabilités courantes (auth, secrets, CORS, headers, injection, validation, etc.).
+
+Tu es **Coordinator**. Tu planifies, délègues à des implementors, vérifies. Tu **n'écris pas de code toi-même**. Tu utilises des **waves** (vague d'implémentation → vérification → vague suivante).
+
+## Phase 1 — Recon (toi, sans déléguer)
+
+Avant de planifier, recense :
+- Lockfiles présents : `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `poetry.lock`, `Pipfile.lock`, `requirements.txt`, `go.sum`, `Cargo.lock`, `composer.lock`, etc.
+- Gestionnaires de secrets : `.env`, `.env.example`, fichiers Terraform, GitHub Actions secrets référencés.
+- Frameworks d'auth en place (JWT, OAuth, sessions, cookies).
+- Surface réseau : routes API publiques, CORS config, reverse proxy, headers HTTP.
+- CI/CD : workflows GitHub Actions / GitLab CI / autre — vérifier pinning des actions tierces.
+
+Lance ces commandes (lecture seule) :
+```bash
+# Node
+npm audit --json 2>/dev/null | head -200
+npm ls --all 2>&1 | head -50
+
+# Python
+poetry show --outdated 2>/dev/null || pip list --outdated
+pip-audit 2>/dev/null || safety check 2>/dev/null
+
+# Secrets dans le repo (sans logger les valeurs)
+git log --all -p | grep -iE "(api[_-]?key|secret|password|token|bearer)" | head -20
+
+# Lockfile drift
+git diff HEAD -- '*.lock' 'package-lock.json' 2>&1 | head -20
+```
+
+Liste ensuite ce que tu trouves dans le Spec **sans révéler de valeurs secrètes** (uniquement les noms de fichiers / paquets / advisories).
+
+## Phase 1.5 — Attaques supply chain connues à vérifier explicitement
+
+Pour chaque attaque ci-dessous, l'implementor DOIT vérifier que le repo n'est pas affecté (lockfile + arbre de dépendances transitives) et documenter le résultat dans le Spec.
+
+### npm — 2025
+
+**Shai-Hulud worm** (septembre 2025)
+- Worm npm auto-réplicant qui vole les tokens des maintainers et republie les paquets compromis.
+- Plus de 500 paquets touchés sur plusieurs vagues.
+- IoCs : présence du fichier `bundle.js` malveillant, scripts `postinstall` exfiltrant `~/.npmrc`, `~/.aws`, `~/.config/gh`, variables d'env.
+- Cibles connues incluent des paquets de `@ctrl/*`, `@nativescript-community/*`, `@crowdstrike/*`, plus rebonds via tokens volés.
+- Commandes de vérif :
+  ```bash
+  # Chercher les versions affectées dans le lockfile (liste à mettre à jour selon advisory GitHub)
+  npm ls --all 2>&1 | grep -iE "@ctrl/tinycolor|@nativescript-community"
+  # Vérifier qu'aucun postinstall n'exfiltre quoi que ce soit
+  find node_modules -name "package.json" -exec grep -l "postinstall" {} \; | head
+  ```
+
+**s1ngularity / nx attack** (août 2025)
+- `nx` et plusieurs plugins (`@nx/*`, `@nrwl/*`) compromis.
+- Versions malveillantes : `nx@20.9.0`, `21.5.0`, `21.6.0`, `21.7.0`, `21.8.0`, et plugins associés sur la même fenêtre.
+- IoCs : script `telemetry.js` exfiltrant tokens GitHub/npm.
+- Vérif : `npm ls nx @nx/* @nrwl/* 2>&1 | grep -v "deduped"`.
+
+**chalk / debug / qix maintainer** (septembre 2024, toujours d'actualité dans les vieux lockfiles)
+- Le maintainer Qix s'est fait phisher, ~20 paquets compromis pendant ~2h : `chalk`, `debug`, `ansi-styles`, `strip-ansi`, `color-convert`, `color-name`, `wrap-ansi`, `supports-color`, `is-arrayish`, `error-ex`, `simple-swizzle`, `has-ansi`, `ansi-regex`, `slice-ansi`.
+- Versions malveillantes spécifiques (ex: `chalk@5.6.1`, `debug@4.4.2`). Liste exacte : GitHub Security Advisory `GHSA-...`.
+- Vérif : `npm audit` + scan manuel des hashes.
+
+### npm — 2024 et avant
+- **lottie-player** (octobre 2024) — `@lottiefiles/lottie-player` compromis.
+- **ua-parser-js** (2021) — versions `0.7.29`, `0.8.0`, `1.0.0` malveillantes.
+- **node-ipc** (mars 2022) — protestware effaçant des fichiers.
+- **event-stream** (2018) — historique mais à vérifier sur vieux projets.
+
+### PyPI
+- **xz-utils backdoor** (CVE-2024-3094, mars 2024) — versions `5.6.0` et `5.6.1` de `xz`/`liblzma`. Pas Python directement mais affecte tout container basé sur Debian/Ubuntu non patché.
+- **ctx** et **phpass** (mai 2022) — paquets typosquattés.
+- **colorama / fake colorama** — typosquatting récurrent.
+- Vérif générique : `pip-audit` + `safety check` + `grep -r "atexit.register" site-packages | head` pour détecter des exfiltrations.
+
+### Actions GitHub
+- **tj-actions/changed-files** (mars 2025) — compromis, exfiltrait les secrets dans les logs publics.
+- Vérif : `grep -r "tj-actions" .github/workflows/` et confirmer pinning par SHA, pas par tag.
+- Plus généralement : tout `uses: <author>/<action>@v...` sans SHA est à reprendre.
+
+### Tâches Spec correspondantes (à ajouter en Wave 1, en plus des génériques)
+
+@@@task
+# Scan Shai-Hulud + worms npm récents
+## Scope
+Vérifier que le lockfile n'inclut aucune version compromise par Shai-Hulud (sept 2025), s1ngularity/nx (août 2025), Qix/chalk (sept 2024), tj-actions, lottie-player, ua-parser-js, node-ipc.
+## Definition of Done
+- Liste exhaustive des paquets vérifiés (nom + version installée + statut: SAFE / COMPROMISED / UPGRADED).
+- Tout paquet compromis : upgrade vers la version safe + audit des secrets potentiellement exfiltrés (rotation tokens npm/GitHub/cloud si compromission confirmée).
+- Document dans le Spec section "Supply chain scan results".
+## Verification
+- `npm audit --audit-level=moderate` clean.
+- `git log --all -p -- package-lock.json` n'introduit pas de versions blacklistées.
+- Pour les actions GitHub : tous les `uses:` pointent vers un SHA 40-char.
+@@@
+
+@@@task
+# Rotation tokens si compromission détectée
+## Scope
+Si la tâche précédente a trouvé un paquet compromis QUI A ÉTÉ INSTALLÉ (pas juste dans le lockfile mais exécuté en CI ou en local par un dev), rotation immédiate de :
+- Tokens npm (CI + locaux des maintainers).
+- Tokens GitHub (PAT, app tokens).
+- Tokens cloud référencés dans les env du CI ou des shells des dev.
+- Cookies de session des services intégrés.
+## Definition of Done
+- Liste des tokens identifiés à risque (par fichier/CI, sans révéler les valeurs).
+- Confirmation utilisateur qu'ils ont été rotés (l'agent ne tourne PAS les tokens lui-même).
+## Verification
+- Documenter dans le Spec : `Token X : rotated YYYY-MM-DD`.
+@@@
+
+@@@task
+# Audit postinstall scripts (toutes deps)
+## Scope
+Lister tous les scripts `preinstall`, `install`, `postinstall` dans `node_modules/*/package.json` et dans `package.json` racine + workspaces. Identifier ceux qui font des accès réseau ou lisent des fichiers sensibles (`~/.npmrc`, `~/.aws`, `~/.ssh`, `~/.config/gh`).
+## Definition of Done
+- Liste des scripts trouvés + verdict (legit / suspect / malveillant).
+- Pour les suspects : analyse manuelle.
+- Recommandation : activer `npm config set ignore-scripts true` côté CI si possible.
+## Verification
+- Pas d'exfiltration détectée dans les scripts.
+@@@
+
+**Notes complémentaires sur la Phase 1.5** :
+- La liste évolue vite — l'implementor doit aussi consulter `https://github.com/advisories?query=type%3Areviewed+ecosystem%3Anpm` et `https://osv.dev/list` au moment où il bosse, plus les dernières 4 semaines de news GitHub Security Lab.
+- Shai-Hulud est en premier vu que c'est l'attaque la plus récente et la plus virulente (auto-réplication).
+- Le pattern « rotation tokens » est critique : si un dev a `npm install` sur une version compromise, ses creds sont potentiellement leakées même si on retire ensuite le paquet du lockfile.
+
+## Phase 2 — Plan (Spec note, format `@@@task`)
+
+Crée une **tâche par catégorie** dans le Spec. Ordre suggéré (par criticité) :
+
+### Wave 1 — Supply chain (CRITIQUE)
+- `@@@task` **Lockfile integrity audit** — vérifier qu'aucun lockfile n'a été modifié hors PR, comparer les hashes intégrité (`integrity` field dans `package-lock.json`).
+- `@@@task` **Compromised packages scan** — chercher les paquets connus comme compromis récemment (consulter advisories npm/PyPI/etc., GitHub Security Advisories, `osv.dev`). Lister chaque hit. Voir aussi les 3 tâches dédiées de la Phase 1.5.
+- `@@@task` **High/Critical CVEs** — `npm audit`, `pip-audit`, `cargo audit`, etc. Fixer ou justifier chaque high/critical.
+- `@@@task` **Dependency pinning** — vérifier que les versions sont pinnées (pas de `^` ou `~` agressifs sur les deps sensibles : auth, crypto, http server). Pour les actions GitHub : pin par SHA, pas par tag.
+- `@@@task` **Renovate/Dependabot config** — vérifier la config (groupage, auto-merge limité, fenêtres de release).
+
+### Wave 2 — Auth & secrets
+- `@@@task` **Audit secrets management** — aucun secret hardcodé, `.env` gitignored, `.env.example` à jour. Vérifier rotation possible.
+- `@@@task` **JWT/session hardening** — si JWT : algo `RS256` ou `HS256` avec secret ≥ 256 bits, `exp` court, refresh tokens si applicable. Vérifier `iss`, `aud`, `nbf`. Cookies : `HttpOnly`, `Secure`, `SameSite=Lax` ou `Strict`.
+- `@@@task` **OAuth/SSO callbacks** — valider `state`, `redirect_uri` whitelist exacte, PKCE pour SPAs publics.
+- `@@@task` **Password storage** (si applicable) — bcrypt/argon2 avec coût adéquat, pas de MD5/SHA1.
+
+### Wave 3 — Surface réseau & HTTP
+- `@@@task` **CORS** — pas de `*` en prod, origines explicites par env, `credentials: true` uniquement si nécessaire.
+- `@@@task` **Security headers** — `Strict-Transport-Security`, `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY` ou CSP `frame-ancestors`, `Referrer-Policy`, `Content-Security-Policy` adapté.
+- `@@@task` **Rate limiting** — sur les endpoints d'auth et coûteux (export, search).
+- `@@@task` **Input validation** — Pydantic/Zod/Joi sur toutes les entrées API, validation longueur/format.
+
+### Wave 4 — Données & accès
+- `@@@task` **SQL injection** — aucun query string concaténée, uniquement params bindés (`text(...)` avec params nommés en SQLAlchemy, prepared statements).
+- `@@@task` **Authorization checks** — vérifier que chaque endpoint contrôle le rôle/scope (pas seulement l'authentification).
+- `@@@task` **IDOR** — vérifier que les `id` dans les URLs sont validés contre l'utilisateur courant (ex: `/api/users/{id}` doit refuser un id qui n'appartient pas à l'utilisateur, sauf admin).
+- `@@@task` **Logging** — pas de secrets/tokens/PII dans les logs ; logs d'audit pour les actions sensibles.
+
+### Wave 5 — CI/CD & infra
+- `@@@task` **GitHub Actions pinning** — `uses: actions/checkout@<sha>` partout, pas `@v4`.
+- `@@@task` **Permissions workflows** — `permissions:` explicites, principe du moindre privilège (`contents: read` par défaut).
+- `@@@task` **Branch protection** — review requise, status checks obligatoires, no force push sur `main`.
+- `@@@task` **Container/Cloud Run** — image base minimale (`distroless`, `alpine`), non-root user, `readOnlyRootFilesystem` si possible. Secrets via Secret Manager, pas via env vars en clair dans les manifestes.
+
+## Phase 3 — Exécution
+
+Pour chaque wave :
+1. STOP, présente le plan au user, attend l'approbation.
+2. Délègue **toutes les tâches de la wave en parallèle** avec `waitMode: "after_all"` et `specialist: "implementor"`.
+3. END TURN, attends la complétion de toute la wave.
+4. Délègue un `specialist: "verifier"` qui relit les diffs et confirme.
+5. Merge les PRs (une par tâche, ou une PR par wave si tu préfères — décide avec l'user).
+
+## Règles strictes
+
+- **Une PR par fix** (sauf petits fixes regroupés explicitement).
+- **Tests** : chaque PR doit ajouter ou garder verts les tests existants.
+- **Branches** : `security/<wave>-<short-desc>` (ex: `security/wave1-npm-audit`).
+- **Cible** : `main` (ou `master` selon le repo).
+- **Squash merge** par défaut.
+- **Jamais de secret en clair** dans les commits, PR body, ou logs (même temporaires).
+- **Prod en dernier** : si un changement touche prod (CORS, headers), feature-flag d'abord, prod en dernière étape.
+- **Rollback plan** documenté dans chaque PR à risque (config infra, deps majeures).
+
+## Livrables attendus
+
+- Spec note maintenue à jour, une section par wave.
+- Une PR par tâche complétée, mergée et déployée en dev/test avant prod.
+- Rapport final : tableau `Catégorie | Avant | Après | Référence (CVE/PR)`.
+
+## Démarrage
+
+1. Renomme le workspace (3-5 mots, sentence case, ex: « Security audit projet X »).
+2. Fais la phase Recon.
+3. Écris le Spec avec toutes les tâches identifiées en `@@@task`.
+4. Présente le plan, demande l'approbation.
+5. Délègue Wave 1.
+
+## Notes d'utilisation de ce prompt
+
+- Remplace les 3 placeholders en haut (`<chemin>`, `<stack>`, `<environnements>`).
+- Si tu sais déjà quels paquets sont compromis sur la stack ciblée, ajoute-les explicitement dans la Phase 1.5 avant de démarrer.
+- Adapte les waves selon la stack : si pas d'OAuth, retire la sous-tâche correspondante.
+- Tu peux retirer des waves entières si déjà faites sur ce projet.

--- a/docs/security-audit-redquest.md
+++ b/docs/security-audit-redquest.md
@@ -1,0 +1,144 @@
+# Audit sécurité supply chain — RedQuest
+
+> Plan d'implémentation établi le 2026-05-15 à partir du cadre méthodologique `docs/security-audit-framework.md` (Coordinator/waves), adapté au contexte RedQuest mono-agent + backend hors scope.
+
+## Contexte projet
+
+- **Repo** : `/Users/tom/Projects/RedQuest`
+- **Stack** : Angular 10.0.14 (legacy, EOL) + Firebase 8.10.1 + AngularFire 6.1.5
+- **Backend** : hors scope (Cloud Functions Python sur `rcq-functions-v2`)
+- **Environnements** : `dev` / `test` / `prod` (Firebase Hosting `rq-fr-{env}.web.app`)
+- **CI/CD** : ❌ Aucune GitHub Action ; deploy via `gcp-deploy.sh` local + Firebase CLI
+- **Node runtime** : v22.22.0 (CLI), Angular 10 attend Node 14 → contournement `NODE_OPTIONS=--openssl-legacy-provider`
+
+## Phase 1 — Recon (état au 2026-05-15)
+
+### Lockfile
+
+| Élément | Valeur |
+|---|---|
+| Format | `package-lock.json` v3 |
+| Entrées avec `integrity` SHA512 | 1938 / 1938 (100%) |
+| Registry unique | ✅ `registry.npmjs.org` exclusivement |
+| Dernière modification | 2026-01-29 (stable, pas de drift suspect) |
+| Postinstall racine | `ngcc` (légitime Angular Ivy) |
+| Postinstall transitifs suspects | ❌ Aucun à depth ≤ 3 |
+
+### `npm audit` baseline
+
+| Sévérité | Count | Nature dominante |
+|---|---|---|
+| Critical | 6 | Build-time only (loader-utils, form-data, pbkdf2, protobufjs, request, sha.js) |
+| High | 83 | ~30 Angular XSS/XSRF runtime + Firebase Admin + grpc + babel |
+| Moderate | 71 | Mixte |
+| Low | 21 | Mixte |
+| **Total** | **181** | |
+
+Snapshot brut : `/tmp/redquest-audit.json` (à committer dans `docs/security-baseline-2026-05-15.json` lors de la Wave 1).
+
+## Phase 1.5 — Scan IoC packages compromis connus
+
+| Attaque | Date | Présence RedQuest | Verdict |
+|---|---|---|---|
+| **Shai-Hulud worm** (`@ctrl/*`, `@nativescript-community/*`) | sept 2025 | ❌ Absent | SAFE |
+| **s1ngularity / nx** (`nx`, `@nx/*`, `@nrwl/*`) | août 2025 | ❌ Absent | SAFE |
+| **Qix / chalk-debug-ansi** | sept 2024 | ⚠️ Familles présentes, versions SAFE (chalk@4.1.2 max, debug@4.4.0 max — compromis: chalk@5.6.1, debug@4.4.2) | SAFE |
+| **lottie-player** (`@lottiefiles/lottie-player`) | oct 2024 | ❌ Absent | SAFE |
+| **ua-parser-js** (versions 0.7.29/0.8.0/1.0.0) | oct 2021 | ✅ `0.7.21` (devDep transitive via karma, antérieure à l'attaque, hash integrity verrouillé) | SAFE |
+| **node-ipc** | mars 2022 | ❌ Absent | SAFE |
+| **event-stream** | 2018 | ❌ Absent | SAFE |
+| **tj-actions/changed-files** | mars 2025 | N/A (pas de GH Actions) | SAFE |
+
+**Conclusion Phase 1.5** : aucune action de rotation de tokens nécessaire. Aucune trace de compromission active ou historique.
+
+## Risques identifiés non-IoC
+
+1. **`firebase-admin@9.0.0` en `dependencies`** (pas devDep) — SDK backend qui ne devrait pas être bundlé côté Angular. À investiguer : si jamais importé dans `src/`, à retirer (`npm uninstall firebase-admin`). Allège l'arbre de `@google-cloud/firestore`, `@grpc/proto-loader`, `protobufjs` qui portent plusieurs critical/high.
+2. **Angular 10 EOL depuis ~déc 2021** — les CVEs Angular XSS/XSRF runtime ne seront pas patchées sans upgrade majeur. Décision à acter : accepter le risque ou planifier upgrade.
+3. **Node 22 vs target Node 14 d'Angular 10** — `--openssl-legacy-provider` masque le décalage. Documenter via `.nvmrc`.
+4. **Pas de CI** — aucun audit automatique, aucune détection de drift sur PRs.
+5. **Outils dev EOL** : `protractor`, `tslint`, `codelyzer` — surface morte mais inerte.
+
+## Waves de remédiation
+
+### Wave 1 — Supply chain (CRITIQUE, ~1h30)
+
+| Task | Action | Risque |
+|---|---|---|
+| 1.1 | Snapshot baseline `npm audit --json` → `docs/security-baseline-2026-05-15.json` | 0 |
+| 1.2 | `npm audit fix` (sans `--force`) + `ng build` + `ng test` ; revue diff `package-lock.json` | Faible |
+| 1.3 | Investigation `firebase-admin` : `grep -rn "firebase-admin" src/` puis `npm uninstall` si non utilisé | Faible |
+| 1.4 | Pin exact versions deps runtime sensibles : `firebase`, `@angular/fire` (retirer `^`) | 0 |
+| 1.5 | Documenter dans README : « toujours `npm ci`, jamais `npm install` en CI » | 0 |
+| 1.6 | Snapshot baseline final post-fixes pour comparaison future | 0 |
+
+### Wave 2 — Secrets / auth client (réduite, ~15 min)
+
+| Task | Action |
+|---|---|
+| 2.1 | `grep -rE "(api[_-]?key\|secret\|password\|token\|bearer)" src/` — counts only, pas de log de valeurs |
+| 2.2 | Vérifier `.gitignore` couvre `environment.{dev,test,prod}.ts` (déjà OK) ; `environment.sample.ts` n'a que des placeholders |
+| 2.3 | Confirmer que les API keys Firebase visibles dans envs sont des clés **publiques web** (limitées par Firestore Security Rules), pas des admin keys |
+| 2.4 | Vérifier `AuthTokenInterceptor` (Phase B migration) : token jamais loggé via `console.*` |
+
+Backend (JWT, OAuth, password storage) : hors scope, déléguer à `rcq-functions-v2`.
+
+### Wave 3 — Surface HTTP (ciblée Firebase Hosting, ~30 min + obs 1 sem)
+
+| Task | Action | Précaution |
+|---|---|---|
+| 3.1 | Security headers dans `firebase.json` : HSTS, X-Content-Type-Options, X-Frame-Options, Referrer-Policy | — |
+| 3.2 | CSP en `Content-Security-Policy-Report-Only` d'abord (1 semaine d'observation) avant enforcement | Risque casse Firebase Auth iframes, Google Maps embed |
+| 3.3 | CORS Cloud Functions : note pour `rcq-functions-v2` — n'autoriser que `rq-fr-{env}.web.app` + `localhost:4200` (dev only) | Hors scope ce repo |
+
+### Wave 4 — Données / accès
+
+**Tout backend → hors scope.** Déléguer à `rcq-functions-v2` (SQL injection, authorization, IDOR, logs).
+
+### Wave 5 — CI/CD (adaptée, ~45 min)
+
+| Task | Action |
+|---|---|
+| 5.1 | Créer `.github/workflows/security-audit.yml` : run sur PR + cron lundi, `npm audit --audit-level=high`, **pinning des actions par SHA 40-char** (pas par tag — protection tj-actions) |
+| 5.2 | Ajouter `.nvmrc` (`22`) ; dans `gcp-deploy.sh` pinner `firebase-tools` via `npx firebase-tools@13.x` au lieu d'install global ; ajouter check `node -v` au début |
+| 5.3 | Branch protection sur `main` (action manuelle GitHub UI) : require PR review, no force push, status check `security-audit` requis |
+| 5.4 | `.github/dependabot.yml` : weekly, groupage Angular + TS, max 5 PRs ouvertes |
+
+## Ordonnancement recommandé
+
+1. **Wave 1 d'abord** (impact max, risque faible).
+2. Wave 2 (5.1) en parallèle car indépendantes.
+3. Wave 3 (CSP) ensuite, en mode Report-Only puis enforcement.
+4. Wave 5.3 (branch protection) à la fin une fois le workflow audit en place.
+
+## Règles d'engagement
+
+- **Une PR par wave** (pragmatique pour un projet de cette taille — pas une par fix).
+- **Branches** : `security/wave-<n>-<short-desc>` (ex: `security/wave-1-supply-chain`).
+- **Tests** : Karma vert obligatoire avant chaque commit ; `ng build --configuration dev` OK.
+- **Aucun secret en clair** dans commits, PR body, logs (même temporaires).
+- **Rollback** : `git revert` simple sur toutes les PRs ; CSP enforcement = phase Report-Only obligatoire.
+- **Rotation tokens** : **non requise** (aucune compromission détectée).
+
+## Décisions en attente
+
+| Question | Options |
+|---|---|
+| Démarrer Wave 1 maintenant ou après migration Cloud Functions ? | Recommandation : finir D2/D3/D4 migration, puis Wave 1 dans PR séparée |
+| CVEs Angular runtime XSS non-fixables sans upgrade | (a) Accepter risque résiduel + documenter (b) Planifier upgrade Angular 10 → latest |
+| CSP enforcement | (a) Inclus Wave 3 en Report-Only (recommandé) (b) Out of scope |
+| `firebase-admin` investigation | Lecture seule (`grep`), donc OK quand tu veux |
+
+## Livrables attendus
+
+- `docs/security-baseline-2026-05-15.json` (audit snapshot avant fixes)
+- `docs/security-baseline-<date-post-wave1>.json` (audit snapshot après)
+- Une PR par wave avec section "Rollback plan" dans la description
+- Rapport final mis à jour à la fin de chaque wave : tableau `Catégorie | Avant | Après | Référence (CVE/PR)`
+
+## Références
+
+- Cadre méthodologique : `docs/security-audit-framework.md`
+- Migration Cloud Functions v1→v2 : `docs/cloud-functions-endpoints.md`
+- GitHub Security Advisories (npm) : https://github.com/advisories?query=type%3Areviewed+ecosystem%3Anpm
+- OSV database : https://osv.dev/list

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,5 +1,5 @@
 import { registerLocaleData } from '@angular/common';
-import { HttpClientModule } from '@angular/common/http';
+import { HTTP_INTERCEPTORS, HttpClientModule } from '@angular/common/http';
 import localeFrExtra from '@angular/common/locales/extra/fr';
 import localeFr from '@angular/common/locales/fr';
 import { NgModule } from '@angular/core';
@@ -7,7 +7,6 @@ import { AngularFireModule } from '@angular/fire';
 import { AngularFireAuth } from '@angular/fire/auth';
 import { AngularFireDatabaseModule } from '@angular/fire/database';
 import { AngularFirestore, SETTINGS } from '@angular/fire/firestore';
-import { AngularFireFunctionsModule, REGION } from '@angular/fire/functions';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
@@ -15,6 +14,7 @@ import { CookieService } from 'ngx-cookie-service';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
+import { AuthTokenInterceptor } from './services/auth/auth-token.interceptor';
 import { CreditsComponent } from './components/credits/credits.component';
 import { HomepageComponent } from './components/homepage/homepage.component';
 import { LocalUnitComponent } from './components/local-unit/local-unit.component';
@@ -45,15 +45,14 @@ registerLocaleData(localeFr, 'fr-FR', localeFrExtra);
         AppRoutingModule,
         SharedModule,
         AngularFireModule.initializeApp(environment.firebaseConfig),
-        AngularFireFunctionsModule,
         AngularFireDatabaseModule,
         BrowserAnimationsModule
     ],
     providers: [
         AngularFirestore, AngularFireAuth, CookieService,
-        { provide: REGION, useValue: 'europe-west1' },
         { provide: MAT_DATE_LOCALE, useValue: 'fr-FR'},
-        { provide: SETTINGS, useValue: {} }
+        { provide: SETTINGS, useValue: {} },
+        { provide: HTTP_INTERCEPTORS, useClass: AuthTokenInterceptor, multi: true }
     ],
     bootstrap: [AppComponent]
 })

--- a/src/app/components/ranking/ranking.component.ts
+++ b/src/app/components/ranking/ranking.component.ts
@@ -24,7 +24,7 @@ export class RankingComponent implements AfterViewInit, OnInit {
   dataSource: RankingDatasource;
   displayedColumns = ['last_name', 'number_of_tronc_queteur', 'amount', 'weight', 'time_spent_in_minutes',
     'unique_point_quete_count', 'year'];
-  years = [2016, 2017, 2018, 2019, 2020];
+  years = Array.from({ length: new Date().getFullYear() - 2016 + 1 }, (_, i) => new Date().getFullYear() - i);
 
   ul_id: number;
   year = new Date().getFullYear();

--- a/src/app/modules/account/account.component.spec.ts
+++ b/src/app/modules/account/account.component.spec.ts
@@ -1,25 +1,11 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 
-import { RegistrationConfirmationComponent } from './registration-confirmation.component';
+import { AccountComponent } from './account.component';
 
-describe('RegistrationConfirmationComponent', () => {
-  let component: RegistrationConfirmationComponent;
-  let fixture: ComponentFixture<RegistrationConfirmationComponent>;
+describe('AccountComponent', () => {
+    beforeEach(() => TestBed.configureTestingModule({}));
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ RegistrationConfirmationComponent ]
-    })
-    .compileComponents();
-  }));
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(RegistrationConfirmationComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
-
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+    it('should be defined', () => {
+        expect(AccountComponent).toBeTruthy();
+    });
 });

--- a/src/app/services/auth/auth-token.interceptor.spec.ts
+++ b/src/app/services/auth/auth-token.interceptor.spec.ts
@@ -1,0 +1,76 @@
+import { HTTP_INTERCEPTORS, HttpClient } from '@angular/common/http';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { AngularFireAuth } from '@angular/fire/auth';
+
+import { environment } from '../../../environments/environment';
+import { AuthTokenInterceptor } from './auth-token.interceptor';
+
+describe('AuthTokenInterceptor', () => {
+
+  const baseUrl = environment.cloudFunctionsBaseUrl;
+  const targetUrl = `${baseUrl}get-ul-prefs`;
+  const externalUrl = 'https://maps.googleapis.com/maps/api/js';
+
+  let http: HttpClient;
+  let httpMock: HttpTestingController;
+  let angularFireAuthStub: { currentUser: Promise<any> };
+
+  function configure(currentUser: Promise<any>): void {
+    angularFireAuthStub = { currentUser };
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        { provide: AngularFireAuth, useValue: angularFireAuthStub },
+        { provide: HTTP_INTERCEPTORS, useClass: AuthTokenInterceptor, multi: true }
+      ]
+    });
+    http = TestBed.inject(HttpClient);
+    httpMock = TestBed.inject(HttpTestingController);
+  }
+
+  afterEach(() => {
+    if (httpMock) {
+      httpMock.verify();
+    }
+  });
+
+  it('injects the Bearer token when the user is authenticated and the URL matches the cloud functions base URL', (done) => {
+    const fakeToken = 'fake-id-token-123';
+    const userStub = { getIdToken: jasmine.createSpy('getIdToken').and.returnValue(Promise.resolve(fakeToken)) };
+    configure(Promise.resolve(userStub));
+
+    http.get(targetUrl).subscribe(() => done());
+
+    setTimeout(() => {
+      const req = httpMock.expectOne(targetUrl);
+      expect(req.request.headers.get('Authorization')).toBe(`Bearer ${fakeToken}`);
+      expect(userStub.getIdToken).toHaveBeenCalled();
+      req.flush({});
+    }, 0);
+  });
+
+  it('does not inject any Authorization header when no user is currently signed in', (done) => {
+    configure(Promise.resolve(null));
+
+    http.get(targetUrl).subscribe(() => done());
+
+    setTimeout(() => {
+      const req = httpMock.expectOne(targetUrl);
+      expect(req.request.headers.has('Authorization')).toBeFalse();
+      req.flush({});
+    }, 0);
+  });
+
+  it('does not touch requests sent to URLs outside the cloud functions base URL', (done) => {
+    const userStub = { getIdToken: jasmine.createSpy('getIdToken').and.returnValue(Promise.resolve('should-not-be-used')) };
+    configure(Promise.resolve(userStub));
+
+    http.get(externalUrl).subscribe(() => done());
+
+    const req = httpMock.expectOne(externalUrl);
+    expect(req.request.headers.has('Authorization')).toBeFalse();
+    expect(userStub.getIdToken).not.toHaveBeenCalled();
+    req.flush({});
+  });
+});

--- a/src/app/services/auth/auth-token.interceptor.ts
+++ b/src/app/services/auth/auth-token.interceptor.ts
@@ -1,0 +1,40 @@
+import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { AngularFireAuth } from '@angular/fire/auth';
+
+import { Observable, from, of } from 'rxjs';
+import { switchMap, take } from 'rxjs/operators';
+
+import { environment } from '../../../environments/environment';
+
+@Injectable()
+export class AuthTokenInterceptor implements HttpInterceptor {
+
+  private readonly cloudFunctionsBaseUrl = environment.cloudFunctionsBaseUrl;
+
+  constructor(private angularFireAuth: AngularFireAuth) { }
+
+  intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+    if (!this.shouldInjectToken(req.url)) {
+      return next.handle(req);
+    }
+
+    return from(this.angularFireAuth.currentUser).pipe(
+      take(1),
+      switchMap(user => user ? from(user.getIdToken()) : of<string | null>(null)),
+      switchMap(token => {
+        if (!token) {
+          return next.handle(req);
+        }
+        const authReq = req.clone({
+          setHeaders: { Authorization: `Bearer ${token}` }
+        });
+        return next.handle(authReq);
+      })
+    );
+  }
+
+  private shouldInjectToken(url: string): boolean {
+    return !!this.cloudFunctionsBaseUrl && url.startsWith(this.cloudFunctionsBaseUrl);
+  }
+}

--- a/src/app/services/cloud-functions/cloud-function-service.service.spec.ts
+++ b/src/app/services/cloud-functions/cloud-function-service.service.spec.ts
@@ -1,12 +1,99 @@
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 
 import { CloudFunctionService } from './cloud-function.service';
+import { environment } from '../../../environments/environment';
+import { Queteur } from '../../model/queteur';
 
 describe('CloudFunctionService', () => {
-    beforeEach(() => TestBed.configureTestingModule({}));
+    let service: CloudFunctionService;
+    let httpMock: HttpTestingController;
+    const baseUrl = environment.cloudFunctionsBaseUrl;
+    const names = environment.cloudFunctionsNames;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [HttpClientTestingModule],
+            providers: [CloudFunctionService]
+        });
+        service = TestBed.inject(CloudFunctionService);
+        httpMock = TestBed.inject(HttpTestingController);
+    });
+
+    afterEach(() => httpMock.verify());
 
     it('should be created', () => {
-        const service: CloudFunctionService = TestBed.inject(CloudFunctionService);
         expect(service).toBeTruthy();
+    });
+
+    it('findQueteurById$ issues GET on the find-queteur-by-id endpoint', () => {
+        service.findQueteurById$().subscribe(res => expect(res).toEqual({id: 42} as any));
+        const req = httpMock.expectOne(`${baseUrl}${names.findQueteurById}`);
+        expect(req.request.method).toBe('GET');
+        req.flush({id: 42});
+    });
+
+    it('findULDetailsByToken$ issues GET with token query param', () => {
+        const token = '11111111-2222-3333-4444-555555555555';
+        service.findULDetailsByToken$(token).subscribe(res => expect(res).toBeTruthy());
+        const req = httpMock.expectOne(`${baseUrl}${names.findULDetailsByToken}?token=${token}`);
+        expect(req.request.method).toBe('GET');
+        req.flush({ul_id: 1});
+    });
+
+    it('getULPrefs$ issues GET on the get-ul-prefs endpoint', () => {
+        service.getULPrefs$().subscribe();
+        const req = httpMock.expectOne(`${baseUrl}${names.getULPrefs}`);
+        expect(req.request.method).toBe('GET');
+        req.flush({ul_id: 1});
+    });
+
+    it('getULStats$ issues GET on the get-ul-stats endpoint', () => {
+        service.getULStats$().subscribe();
+        const req = httpMock.expectOne(`${baseUrl}${names.getULStats}`);
+        expect(req.request.method).toBe('GET');
+        req.flush({ul_id: 1});
+    });
+
+    it('registerQueteur$ POSTs the queteur and returns the parsed JSON token', () => {
+        const queteur = {first_name: 'a', last_name: 'b'} as Queteur;
+        service.registerQueteur$(queteur).subscribe(res =>
+            expect(res.queteur_registration_token).toBe('uuid-1234')
+        );
+        const req = httpMock.expectOne(`${baseUrl}${names.registerQueteur}`);
+        expect(req.request.method).toBe('POST');
+        expect(req.request.body).toEqual(queteur);
+        req.flush({queteur_registration_token: 'uuid-1234'});
+    });
+
+    it('retrievePreparedTroncs$ converts depart_theorique and depart to Date', () => {
+        let received: any[];
+        service.retrievePreparedTroncs$().subscribe(rows => received = rows);
+        const req = httpMock.expectOne(`${baseUrl}${names.troncListPrepared}`);
+        expect(req.request.method).toBe('GET');
+        req.flush([
+            {tronc_queteur_id: 1, depart_theorique: '2024-05-01T08:00:00Z', depart: '2024-05-01T08:15:00Z'},
+            {tronc_queteur_id: 2, depart_theorique: '2024-05-01T10:00:00Z', depart: null}
+        ]);
+        expect(received[0].depart_theorique instanceof Date).toBeTrue();
+        expect(received[0].depart instanceof Date).toBeTrue();
+        expect(received[1].depart_theorique instanceof Date).toBeTrue();
+        expect(received[1].depart).toBeNull();
+    });
+
+    it('troncStateUpdate$ POSTs the update payload', () => {
+        const update = {isDepart: true, date: '2024-05-01 06:00:00', tqId: 99};
+        service.troncStateUpdate$(update).subscribe(res => expect(res.success).toBeTrue());
+        const req = httpMock.expectOne(`${baseUrl}${names.troncSetDepartOrRetour}`);
+        expect(req.request.method).toBe('POST');
+        expect(req.request.body).toEqual(update);
+        req.flush({success: true});
+    });
+
+    it('historiqueTroncQueteur$ issues GET on the historique endpoint', () => {
+        service.historiqueTroncQueteur$().subscribe(res => expect(Array.isArray(res)).toBeTrue());
+        const req = httpMock.expectOne(`${baseUrl}${names.historiqueTroncQueteur}`);
+        expect(req.request.method).toBe('GET');
+        req.flush([]);
     });
 });

--- a/src/app/services/cloud-functions/cloud-function.service.ts
+++ b/src/app/services/cloud-functions/cloud-function.service.ts
@@ -1,9 +1,8 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { AngularFireFunctions } from '@angular/fire/functions';
 
 import { Observable } from 'rxjs';
-import {map, tap} from 'rxjs/operators';
+import { map } from 'rxjs/operators';
 
 import { environment } from '../../../environments/environment';
 import { ULDetails } from '../../model/ULDetails';
@@ -11,38 +10,59 @@ import { ULPrefs } from '../../model/ULPrefs';
 import { ULStats } from '../../model/ULStats';
 import { HistoriqueTroncQueteur } from '../../model/historiqueTroncQueteur';
 import { Queteur } from '../../model/queteur';
+import { Tronc } from '../../model/tronc';
 
 @Injectable({
   providedIn: 'root'
 })
 export class CloudFunctionService {
-  baseUrl = environment.cloudFunctionsBaseUrl;
+  private readonly baseUrl = environment.cloudFunctionsBaseUrl;
+  private readonly functionNames = environment.cloudFunctionsNames;
 
-  constructor(private firebaseFunctions: AngularFireFunctions, private http: HttpClient) { }
+  constructor(private http: HttpClient) { }
 
-  findQueteurById$ = (): Observable<any> => this.firebaseFunctions.httpsCallable('findQueteurById')({});
+  findQueteurById$ = (): Observable<Queteur> =>
+    this.http.get<Queteur>(this.url(this.functionNames.findQueteurById))
 
   findULDetailsByToken$ = (token: string): Observable<ULDetails> =>
-    this.http.get<ULDetails>(`${this.baseUrl}findULDetailsByToken?token=${token}`)
+    this.http.get<ULDetails>(`${this.url(this.functionNames.findULDetailsByToken)}?token=${token}`)
 
+  getULPrefs$ = (): Observable<ULPrefs> =>
+    this.http.get<ULPrefs>(this.url(this.functionNames.getULPrefs))
 
-  getULPrefs$ = (): Observable<any> => this.firebaseFunctions.httpsCallable('getULPrefs')(ULPrefs);
-  getULStats$ = (): Observable<any> => this.firebaseFunctions.httpsCallable('getULStats')(ULStats).pipe(tap(data=>console.log("getULStats",data)));
+  getULStats$ = (): Observable<ULStats> =>
+    this.http.get<ULStats>(this.url(this.functionNames.getULStats))
 
-  registerQueteur$ = (user: Queteur): Observable<any> => this.firebaseFunctions.httpsCallable('registerQueteur')(user)
-    .pipe(map(value => JSON.parse(value)))
+  registerQueteur$ = (user: Queteur): Observable<{ queteur_registration_token: string }> =>
+    this.http.post<{ queteur_registration_token: string }>(
+      this.url(this.functionNames.registerQueteur),
+      user
+    )
 
-  retrievePreparedTroncs$ = (): Observable<any> =>
-    this.firebaseFunctions.httpsCallable('troncListPrepared')({})
-      .pipe(map(value => JSON.parse(value, (k, v) => {
-        if (k === 'depart_theorique' || k === 'depart' || k === 'arrivee') {
-          return new Date(v);
-        }
-        return v;
-      })))
+  retrievePreparedTroncs$ = (): Observable<Tronc[]> =>
+    this.http.get<Tronc[]>(this.url(this.functionNames.troncListPrepared))
+      .pipe(map(rows => rows.map(row => this.parseTroncDates(row))))
 
-  troncStateUpdate$ = (troncUpdate: { isDepart: boolean, date: string, tqId: number }): Observable<any> =>
-    this.firebaseFunctions.httpsCallable('troncSetDepartOrRetour')(troncUpdate)
+  troncStateUpdate$ = (troncUpdate: { isDepart: boolean, date: string, tqId: number }): Observable<{ success: boolean }> =>
+    this.http.post<{ success: boolean }>(
+      this.url(this.functionNames.troncSetDepartOrRetour),
+      troncUpdate
+    )
 
-  historiqueTroncQueteur$ = (): Observable<HistoriqueTroncQueteur[]> => this.firebaseFunctions.httpsCallable('historiqueTroncQueteur')({});
+  historiqueTroncQueteur$ = (): Observable<HistoriqueTroncQueteur[]> =>
+    this.http.get<HistoriqueTroncQueteur[]>(this.url(this.functionNames.historiqueTroncQueteur))
+
+  private url(name: string): string {
+    return `${this.baseUrl}${name}`;
+  }
+
+  private parseTroncDates(row: any): Tronc {
+    if (row.depart_theorique) {
+      row.depart_theorique = new Date(row.depart_theorique);
+    }
+    if (row.depart) {
+      row.depart = new Date(row.depart);
+    }
+    return row as Tronc;
+  }
 }

--- a/src/environments/environment.sample.ts
+++ b/src/environments/environment.sample.ts
@@ -13,6 +13,17 @@ export const environment = {
     messagingSenderId: 'MESSAGING_SENDER_ID'
   },
   cloudFunctionsBaseUrl: 'CLOUD_FUNCTIONS_BASE_URL',
+  cloudFunctionsNames: {
+    findQueteurById: 'find-queteur-by-id',
+    findULDetailsByToken: 'find-ul-details-by-token',
+    troncSetDepartOrRetour: 'tronc-set-depart-or-retour',
+    registerQueteur: 'register-queteur',
+    troncListPrepared: 'tronc-list-prepared',
+    resyncQueteurIdToFirestore: 'resync-queteur-id-to-firestore',
+    historiqueTroncQueteur: 'historique-tronc-queteur',
+    getULPrefs: 'get-ul-prefs',
+    getULStats: 'get-ul-stats'
+  },
   google_maps_key: 'YOUR_GOOGLE_MAPS_EMBED_API_KEY',
   ranking_enabled: true,
   history_enabled: true,


### PR DESCRIPTION
# Migrate Cloud Functions calls to v2 HTTP endpoints (Python backend)

## Context
The backend Cloud Functions are migrating from NodeJS Gen1 Callable to
Python Gen2 HTTP (project `rcq-functions-v2`). This PR refactors the
Angular client to:
- call HTTP endpoints with kebab-case names instead of camelCase
  Callables
- inject Firebase ID tokens via a standard `Authorization: Bearer ...`
  header through an `HttpInterceptor`
- drop the proprietary `@angular/fire/functions` dependency from
  runtime code

## Scope
- `CloudFunctionService` rewritten on top of `HttpClient` (9 methods)
- `AuthTokenInterceptor` added, registered in `AppModule`
- `AngularFireFunctionsModule` and `REGION` provider removed
- Environment files updated with new kebab-case endpoint names and
  v2 base URL (`https://europe-west1-rq-fr-{env}.cloudfunctions.net/`)
- Tests refactored to use `HttpClientTestingModule`
- Documentation added: API contracts + security audit plan
- README setup instructions refreshed
- Ranking dropdown: dynamic year range 2016 -> current year (desc)

## Out of scope
- Backend implementation (lives in `rcq-functions-v2`)
- 401/refresh-token retry logic (skipped, not encountered during E2E)
- Wave 1 supply-chain remediation (separate PR, plan in
  `docs/security-audit-redquest.md`)

## Validation (D2 - manual E2E on `rq-fr-dev`)
- [x] `ng serve --configuration dev` compiles without errors
- [x] `get-ul-prefs` -> 200 OK, `Authorization: Bearer eyJ...` present,
      CORS headers OK
- [x] `tronc-list-prepared` -> 200 OK with Bearer
- [x] Token automatically injected by interceptor on every CF request
- [ ] Full flow coverage (registration, depart/retour, historique) -
      best-effort manual checks, OK on a clean dev account

## Tests
- `ng test --watch=false` - Karma suite green
- `ng build --configuration dev` - OK

## Rollback plan
- Revert this PR (no DB migration, no destructive change).
- Cloud Functions v1 NodeJS endpoints remain available on the legacy
  project until both `rcq-functions-v2` rollout and this client are
  stable. Reverting the client alone is sufficient to fall back.

## Commits
1. `feat(cloud-functions): migrate to HTTP v2 endpoints with Bearer auth`
2. `chore(test): repair pre-existing account.component.spec`
3. `docs(cloud-functions): API contracts and security audit plan`
4. `docs(readme): refresh setup instructions`
5. `feat(ranking): dynamic year range 2016 -> current year (descending)`

## Related
- Backend project: `rcq-functions-v2`
- Migration log + contracts: `docs/cloud-functions-endpoints.md`
- Security audit plan: `docs/security-audit-redquest.md`


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author