### PR TITLE
Security Wave 3 - HTTP security headers and CSP Report-Only

### DIFF
--- a/docs/security-audit-redquest.md
+++ b/docs/security-audit-redquest.md
@@ -101,11 +101,43 @@ Backend (JWT, OAuth, password storage) : hors scope, déléguer à `rcq-function
 
 ### Wave 3 — Surface HTTP (ciblée Firebase Hosting, ~30 min + obs 1 sem)
 
-| Task | Action | Précaution |
+| Task | Action | Précaution | Statut |
+|---|---|---|---|
+| 3.1 | Security headers dans `firebase.json` : HSTS, X-Content-Type-Options, X-Frame-Options, Referrer-Policy | — | ✅ |
+| 3.2 | CSP en `Content-Security-Policy-Report-Only` d'abord (1 semaine d'observation) avant enforcement | Risque casse Firebase Auth iframes, Google Maps embed | ✅ Report-Only |
+| 3.3 | CORS Cloud Functions : note pour `rcq-functions-v2` — n'autoriser que `rq-fr-{env}.web.app` + `localhost:4200` (dev only) | Hors scope ce repo | ⏭ Délégué |
+
+#### Headers déployés (post-Wave 3)
+
+| Header | Valeur |
+|---|---|
+| `X-Frame-Options` | `DENY` (déjà présent avant Wave 3) |
+| `X-Content-Type-Options` | `nosniff` |
+| `Referrer-Policy` | `strict-origin-when-cross-origin` |
+| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains` (1 an, pas de `preload` initialement) |
+| `Content-Security-Policy-Report-Only` | voir `firebase.json` |
+
+#### CSP — directives et sources
+
+| Directive | Sources autorisées | Raison |
 |---|---|---|
-| 3.1 | Security headers dans `firebase.json` : HSTS, X-Content-Type-Options, X-Frame-Options, Referrer-Policy | — |
-| 3.2 | CSP en `Content-Security-Policy-Report-Only` d'abord (1 semaine d'observation) avant enforcement | Risque casse Firebase Auth iframes, Google Maps embed |
-| 3.3 | CORS Cloud Functions : note pour `rcq-functions-v2` — n'autoriser que `rq-fr-{env}.web.app` + `localhost:4200` (dev only) | Hors scope ce repo |
+| `default-src` | `'self'` | Baseline restrictive |
+| `script-src` | `'self'` + `apis.google.com` + `www.gstatic.com` | Firebase Auth SDK (Google Sign-In) ; pas de `'unsafe-eval'` (Angular AOT prod) |
+| `style-src` | `'self'` + `'unsafe-inline'` + `fonts.googleapis.com` + `use.fontawesome.com` | Angular Material injecte des styles inline ; Google Fonts + FontAwesome via `<link>` |
+| `font-src` | `'self'` + `fonts.gstatic.com` + `use.fontawesome.com` + `data:` | Fichiers de fonts Google + FontAwesome |
+| `img-src` | `'self'` + `data:` + `https:` | Permissif pour les icônes Material et assets externes |
+| `connect-src` | `'self'` + 3× `cloudfunctions.net` (dev/test/prod) + 3× `firebaseio.com` + `wss://*.firebaseio.com` + Firestore + Identity Toolkit + Secure Token + `googleapis.com` + `firebaseinstallations.googleapis.com` | XHR/WS Firebase et Cloud Functions |
+| `frame-src` | `'self'` + `www.google.com` + `www.youtube.com` + 3× `rq-fr-{env}.firebaseapp.com` | Google Maps embed, tip YouTube, iframe Firebase Auth |
+| `object-src` | `'none'` | Bloquer Flash/Java legacy |
+| `base-uri` | `'self'` | Anti `<base href>` injection |
+| `form-action` | `'self'` | Anti exfiltration POST |
+| `frame-ancestors` | `'none'` | Équivalent moderne de `X-Frame-Options: DENY` |
+
+#### Mode Report-Only — observation 1 semaine
+
+Aucun `report-uri` configuré (pas d'endpoint de collecte). Les violations sont observables via la console DevTools du navigateur en prod. Si après une semaine d'usage réel aucun warning bloquant n'apparaît, basculer en enforcement en renommant le header `Content-Security-Policy-Report-Only` → `Content-Security-Policy` dans une PR séparée.
+
+Effets attendus si bug : aucun à ce stade (Report-Only n'enforce rien, génère uniquement des warnings console).
 
 ### Wave 4 — Données / accès
 

--- a/firebase.json
+++ b/firebase.json
@@ -12,12 +12,18 @@
         "destination": "/index.html"
       }
     ],
-    "headers": [ {
-      "source": "**/*",
-      "headers": [
-        {"key": "X-Frame-Options", "value": "DENY"}
-      ]
-    }]
+    "headers": [
+      {
+        "source": "**/*",
+        "headers": [
+          {"key": "X-Frame-Options", "value": "DENY"},
+          {"key": "X-Content-Type-Options", "value": "nosniff"},
+          {"key": "Referrer-Policy", "value": "strict-origin-when-cross-origin"},
+          {"key": "Strict-Transport-Security", "value": "max-age=31536000; includeSubDomains"},
+          {"key": "Content-Security-Policy-Report-Only", "value": "default-src 'self'; script-src 'self' https://apis.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://use.fontawesome.com; font-src 'self' https://fonts.gstatic.com https://use.fontawesome.com data:; img-src 'self' data: https:; connect-src 'self' https://europe-west1-rq-fr-dev.cloudfunctions.net https://europe-west1-rq-fr-test.cloudfunctions.net https://europe-west1-rq-fr-prod.cloudfunctions.net https://rq-fr-dev.firebaseio.com https://rq-fr-test.firebaseio.com https://rq-fr-prod.firebaseio.com wss://*.firebaseio.com https://firestore.googleapis.com https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://www.googleapis.com https://firebaseinstallations.googleapis.com; frame-src 'self' https://www.google.com https://www.youtube.com https://rq-fr-dev.firebaseapp.com https://rq-fr-test.firebaseapp.com https://rq-fr-prod.firebaseapp.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'"}
+        ]
+      }
+    ]
   },
   "firestore": {
     "rules": "firestore.rules",


### PR DESCRIPTION
# Security Wave 3 — HTTP security headers + CSP Report-Only

Implements Wave 3 of `docs/security-audit-redquest.md`. Hardens
Firebase Hosting response headers; ships CSP in **Report-Only** mode
for a one-week observation window before enforcement.

## Changes

### Added headers (applied to `**/*` via the existing wildcard source)

| Header | Value |
|---|---|
| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains` |
| `X-Content-Type-Options` | `nosniff` |
| `Referrer-Policy` | `strict-origin-when-cross-origin` |
| `Content-Security-Policy-Report-Only` | see `firebase.json` |

`X-Frame-Options: DENY` was already present and is kept.

### CSP directives (Report-Only)

| Directive | Sources | Why |
|---|---|---|
| `default-src` | `'self'` | restrictive baseline |
| `script-src` | `'self'` + `apis.google.com` + `www.gstatic.com` | Firebase Auth / Google Sign-In SDK |
| `style-src` | `'self'` + `'unsafe-inline'` + `fonts.googleapis.com` + `use.fontawesome.com` | Angular Material injects inline styles |
| `font-src` | `'self'` + `fonts.gstatic.com` + `use.fontawesome.com` + `data:` | Google Fonts + FontAwesome files |
| `img-src` | `'self'` + `data:` + `https:` | Material icons + external assets |
| `connect-src` | `'self'` + 3× `cloudfunctions.net` + 3× `firebaseio.com` + `wss://*.firebaseio.com` + Firestore + Identity Toolkit + Secure Token + `googleapis.com` + `firebaseinstallations.googleapis.com` | Cloud Functions, Firestore, Firebase Auth/RTDB |
| `frame-src` | `'self'` + `www.google.com` + `www.youtube.com` + 3× `rq-fr-{env}.firebaseapp.com` | Google Maps embed, YouTube tip, Firebase Auth iframe |
| `object-src` | `'none'` | block legacy plugins |
| `base-uri` | `'self'` | anti `<base href>` injection |
| `form-action` | `'self'` | anti POST exfiltration |
| `frame-ancestors` | `'none'` | modern equivalent of `X-Frame-Options: DENY` |

No `'unsafe-eval'` (Angular AOT prod). No `'unsafe-inline'` for `script-src`.

## Verification

- JSON validated: `node -e "require('./firebase.json')"` OK
- No build/test impact: `firebase.json` is consumed by Firebase Hosting at deploy time only, not by `ng build` / `ng test` / runtime bundle. Karma and dev build status are therefore unchanged from `master`.
- Post-deploy verification (manual, by deployer):
  - `curl -I https://rq-fr-dev.web.app/` → headers present
  - DevTools Network tab → confirm headers on `index.html` response
  - DevTools Console → watch CSP violation warnings during ~1 week of real usage

## Report-Only → Enforcement

This PR ships `Content-Security-Policy-Report-Only` (warnings only, no blocking). If after one week of observation no critical violation is reported by users / monitoring, a follow-up PR will rename the header to `Content-Security-Policy` (enforcement).

No `report-uri` is configured (no collection endpoint). Observation is manual via DevTools console.

## Out of scope

- **3.3 CORS Cloud Functions** : belongs to `rcq-functions-v2` repo, not this one. Documented in `docs/security-audit-redquest.md` as `⏭ Délégué`.

## Rollback

Single trivial commit, revert with `git revert`. The change is entirely declarative in one file (`firebase.json`); the documentation update has no runtime effect.

## Related

- Wave 1: #122 (merged)
- Wave 1bis: #123 (merged)
- Wave 2: completed read-only, no PR (audit findings logged in `docs/security-audit-redquest.md`)
- Plan: `docs/security-audit-redquest.md`
