### PR TITLE
fix(deploy): make gcp-deploy.sh fully non-interactive

### DIFF
--- a/gcp-deploy.sh
+++ b/gcp-deploy.sh
@@ -93,13 +93,24 @@ echo "Deploying rq-${COUNTRY}-${ENV} (${DEPLOY_MSG})"
 
 export NODE_OPTIONS=--openssl-legacy-provider
 
+# Restrict the deploy targets to hosting + firestore.rules. We deliberately
+# exclude firestore:indexes from the default deploy because firebase prompts
+# interactively to delete any server-side index that is missing from
+# firestore.indexes.json, which both breaks unattended runs and is destructive
+# by default. Indexes are deployed explicitly with:
+#   npx firebase-tools@15 deploy --only firestore:indexes --project rq-${COUNTRY}-${ENV}
+# after reviewing the diff between the live indexes and firestore.indexes.json.
+DEPLOY_TARGETS="hosting,firestore:rules"
+
 if [[ ${ENV} != "prod" ]]
 then
   ng build --configuration "${ENV}" \
-    && ${FIREBASE} deploy --project "rq-${COUNTRY}-${ENV}" --message "${DEPLOY_MSG}"
+    && ${FIREBASE} deploy --only "${DEPLOY_TARGETS}" --non-interactive \
+         --project "rq-${COUNTRY}-${ENV}" --message "${DEPLOY_MSG}"
 else
   ng build --configuration=production \
-    && ${FIREBASE} deploy --project "rq-${COUNTRY}-${ENV}" --message "${DEPLOY_MSG}"
+    && ${FIREBASE} deploy --only "${DEPLOY_TARGETS}" --non-interactive \
+         --project "rq-${COUNTRY}-${ENV}" --message "${DEPLOY_MSG}"
 fi
 
 echo "Deployed to: https://rq-${COUNTRY}-${ENV}.web.app"


### PR DESCRIPTION
## Problem

`./gcp-deploy.sh fr test` (and prod) hung at a Firebase interactive prompt:

```
? Would you like to delete these indexes? Selecting no will continue the rest of the deployment. (y/N)
Error: An unexpected error has occurred.
```

The previous `firebase deploy` invocation (without `--only`) implicitly included `firestore:indexes`, which prompts to delete any server-side index missing from `firestore.indexes.json`. Because the deploy is meant to run unattended, the prompt aborted the run **right after uploading `firestore.rules`** and **before deploying hosting**.

For `rq-fr-test`, 9 `ul_queteur_stats_per_year` composite indexes are present on the project but absent from the local file, which is what triggers the prompt.

## Fix

- Scope the deploy to `--only hosting,firestore:rules` (drop `firestore:indexes` from the default deploy).
- Add `--non-interactive` as a safety net so any future prompt fail-fast instead of hanging.
- Document that indexes are now deployed explicitly with `firebase deploy --only firestore:indexes --project rq-fr-<env>` after reviewing the diff between the live indexes and `firestore.indexes.json`.

## Follow-up (separate work, not this PR)

Reconcile `firestore.indexes.json` with the live indexes on `rq-fr-test` and `rq-fr-prod` so the file is the source of truth again.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author