### PR TITLE
fix(routing): show registration-needed landing to anonymous users on /

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -7,10 +7,11 @@ import { HomepageComponent } from './components/homepage/homepage.component';
 import { LocalUnitComponent } from './components/local-unit/local-unit.component';
 import { RankingComponent } from './components/ranking/ranking.component';
 import { TipsComponent } from './components/tips/tips.component';
+import { RootRedirectGuard } from './root-redirect.guard';
 import { QueteurResolverService } from './services/queteur/queteur.service';
 
 const routes: Routes = [
-  { path: '', redirectTo: '/quest/badges', pathMatch: 'full'},
+  { path: '', canActivate: [RootRedirectGuard], children: [], pathMatch: 'full' },
   { path: 'home', component: HomepageComponent, canActivate: [AuthGuard], resolve: { queteur: QueteurResolverService } },
   { path: 'login', loadChildren: () => import('./modules/login/login.module').then(m => m.LoginModule) },
   {

--- a/src/app/auth-guard.ts
+++ b/src/app/auth-guard.ts
@@ -13,5 +13,5 @@ export class AuthGuard implements CanActivate {
   constructor(private router: Router, private authService: AuthService) { }
 
   canActivate = (route: ActivatedRouteSnapshot, state: RouterStateSnapshot):
-    Observable<boolean> => this.authService.isLoggedIn(false)
+    Observable<boolean> => this.authService.isLoggedIn()
 }

--- a/src/app/root-redirect.guard.ts
+++ b/src/app/root-redirect.guard.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, Router, UrlTree } from '@angular/router';
+import { AngularFireAuth } from '@angular/fire/auth';
+
+import { Observable } from 'rxjs';
+import { map, take } from 'rxjs/operators';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class RootRedirectGuard implements CanActivate {
+
+  constructor(private router: Router, private angularFireAuth: AngularFireAuth) { }
+
+  canActivate(): Observable<UrlTree> {
+    return this.angularFireAuth.user.pipe(
+      take(1),
+      map(user => this.router.createUrlTree(
+        user ? ['/quest/badges'] : ['/registration/needed']
+      ))
+    );
+  }
+}


### PR DESCRIPTION
## Problème

Un visiteur anonyme arrivant sur `/` voyait une page blanche sous la toolbar :

- `/` redirigeait vers `/quest/badges` (`pathMatch: 'full'`).
- `AuthGuard.canActivate` appelait `isLoggedIn(false)` pour la route `quest`.
- `isLoggedIn(false)` renvoyait `false` **sans** naviguer ailleurs (l'argument explicite `redirect=false` désactivait le fallback vers `/login`).
- Le router refusait donc d'activer la route et le `<router-outlet>` restait vide.

Le même symptôme se produisait sur toute route gardée (ex. bookmark vers `/quest/badges` après expiration de session).

## Correctif

Deux changements chirurgicaux :

### 1. Nouveau `RootRedirectGuard`

Attaché à la route racine. Lit l'état Firebase Auth une fois et renvoie un `UrlTree` :

- utilisateur loggé   → `/quest/badges` (destination inchangée)
- utilisateur anonyme → `/registration/needed` (page d'accueil existante qui décrit l'application et la procédure d'inscription)

### 2. `AuthGuard` rétabli en mode "redirect"

`isLoggedIn()` (default `redirect=true`) au lieu de `isLoggedIn(false)`. Tout anonyme atterrissant sur une route gardée est désormais correctement redirigé vers `/login` au lieu de rester sur un outlet vide.

## Matrice de comportement

| Route | État auth | Résultat |
|---|---|---|
| `/` | anonyme | → `/registration/needed` |
| `/` | loggé | → `/quest/badges` |
| `/quest/badges` | anonyme | → `/login` |
| `/quest/badges` | loggé | rend `quest/badges` |
| `/login`, `/registration` | quelconque | rend (pas de guard) |

Validation manuelle effectuée sur `https://rq-fr-dev.web.app` avant ouverture de la PR.

## Hors scope (assumé)

Les tests unitaires des deux guards ne sont pas ajoutés dans cette PR pour garder le diff minimal et débloquer rapidement le fix UX. La dette est tracée dans `docs/todo.md` section "Test suite — sortir du mode focus" (sur la branche `perf/bundle-size-and-optimizations`, arrivera sur master via la PR perf).

## Fichiers touchés

- `src/app/root-redirect.guard.ts` (nouveau, 23 lignes)
- `src/app/app-routing.module.ts` (route racine + import)
- `src/app/auth-guard.ts` (1 ligne : retrait de l'argument `false`)

3 fichiers, +26 / -2.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author