### PR TITLE
chore(vscode): align IDE TypeScript with project version (3.9.10)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib"
+}


### PR DESCRIPTION
## Problème

VSCode (TypeScript Language Server intégré, TS 5.x/6.x) signale plusieurs diagnostics sur les `tsconfig.*.json` du projet, qui sont en réalité écrits pour **TypeScript 3.9.10** (la version livrée par Angular 10) :

- `tsconfig.json` : `File 'src/**/*.ts' not found` (glob non accepté dans `"files"`)
- `tsconfig.json` : 3 × `Referenced project ... must have setting "composite": true`
- `tsconfig.spec.json` : 4 × `Option '...' is deprecated and will stop functioning in TS 7.0` (`baseUrl`, `downlevelIteration`, `moduleResolution=node10`, `target=ES5`)

Aucun de ces diagnostics n'affecte `ng build` ni `ng test` qui utilisent bien `typescript@3.9.10` depuis `node_modules` et compilent sans erreur.

## Correctif

Ajout d'un `.vscode/settings.json` (3 lignes) qui force le language server VSCode à utiliser le TypeScript du workspace au lieu de celui embarqué dans l'éditeur :

```json
{
  "typescript.tsdk": "node_modules/typescript/lib"
}
```

Les diagnostics IDE disparaissent immédiatement (TS 3.9 accepte tous ces patterns sans broncher).

## Vérifications

- `.gitignore` whitelist déjà `.vscode/settings.json` (`!.vscode/settings.json` ligne présente)
- Aucun changement de code applicatif
- Aucun changement de config build (`tsconfig.*.json`, `angular.json`, `package.json` intouchés)
- Le fichier sera automatiquement pris en compte au prochain ouvrir du workspace par tout contributeur

## Long terme

La correction définitive (passer le projet à TS 5+ avec configs à jour) est tracée dans `docs/todo.md` sous "Niveau 3 — Modernisation complète de la stack".

## Risque

Nul. Pure configuration éditeur, aucun impact sur la chaine de build, les tests, ou le runtime.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author