### PR TITLE
chore(vscode): also expose TypeScript SDK path via js/ts.tsdk.path

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "js/ts.tsdk.path": "node_modules/typescript/lib"
 }


### PR DESCRIPTION
## Contexte

Follow-up de #138. Ajoute une seconde clé `"js/ts.tsdk.path"` dans `.vscode/settings.json` à côté de la clé standard `"typescript.tsdk"` déjà présente.

L'objectif : qu'une extension VSCode ou outillage qui lit cette clé alternative (au lieu de la clé native VSCode) pointe lui aussi sur le TypeScript du workspace (`node_modules/typescript/lib`, 3.9.10).

## Diff

```json
{
   "typescript.tsdk": "node_modules/typescript/lib",
+  "js/ts.tsdk.path": "node_modules/typescript/lib"
}
```

## Impact

- **Aucun** sur le language server VSCode natif (qui continue de lire `typescript.tsdk`).
- Purement additif, aucune régression possible.

## Risque

Nul. Configuration éditeur, hors chaine build/test/runtime.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author