### PR TITLE
chore(deploy): add 'indexes' subcommand to gcp-deploy.sh

### DIFF
--- a/docs/cloud-functions-endpoints.md
+++ b/docs/cloud-functions-endpoints.md
@@ -201,4 +201,33 @@ Une fois la fonction déployée et le frontend migré (PR séparée), les élém
 
 Ces nettoyages sont **hors scope** de la spec backend mais à tracer dans la même issue côté frontend.
 
+## 12. Index Firestore (`firestore.indexes.json`)
+
+Catalogue des index composites requis par les Cloud Functions v2. Sans ces index, les requêtes serveur renvoient `400 The query requires an index` et la page concernée tombe en erreur côté client.
+
+| # | Collection | Champs (ordre) | Cloud Function | Requête | Consommateur final |
+|---|---|---|---|---|---|
+| 1 | `ul_queteur_stats_per_year` | `queteur_id` ASC + `year` DESC | `get-queteur-stats` | `.where('queteur_id','==',X).order_by('year', DESC)` | `QueteurHistoryComponent` (Mon historique), `BadgesService` (Mes quêtes) |
+| 2 | `ul_queteur_stats_per_year` | `ul_id` ASC + `year` ASC + `amount` DESC | `get-ul-queteur-ranking` | `.where('ul_id','==',X).where('year','==',Y).order_by('amount', DESC)` | `RankingComponent` / `RankingDatasource` (Classement UL) |
+
+### 12.1 Déploiement
+
+Le déploiement standard (`./gcp-deploy.sh fr <env>`) **n'inclut pas** `firestore:indexes` (`DEPLOY_TARGETS="hosting,firestore:rules"`) pour éviter qu'une modification locale supprime un index serveur de manière silencieuse. Les index ont leur propre sous-commande :
+
+```
+./gcp-deploy.sh fr <env> indexes
+```
+
+Cette commande appelle `firebase deploy --only firestore:indexes --non-interactive --force`. `firestore.indexes.json` est la source de vérité unique : tout écart côté serveur sera réconcilié sans prompt, créations et suppressions confondues. À lancer après chaque modification du fichier, sur les trois environnements (`dev` → `test` → `prod`).
+
+Après création, un index passe par un état `CREATING` (5-15 min selon le volume de documents) avant de devenir `READY` et de servir les requêtes.
+
+### 12.2 Ajouter un nouvel index
+
+1. Ajouter l'entrée dans `firestore.indexes.json` (ordre des champs important — il doit matcher la query exacte).
+2. Ajouter une ligne dans le tableau §12 ci-dessus en référençant la Cloud Function et le composant Angular consommateur.
+3. `./gcp-deploy.sh fr dev indexes` → vérifier dans la Firebase Console que l'état passe à `READY`.
+4. Tester la query côté application (page concernée doit charger sans 400).
+5. Répéter sur `test` puis `prod`.
+
 

--- a/gcp-deploy.sh
+++ b/gcp-deploy.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 COUNTRY=${1:-}
 ENV=${2:-}
+COMMAND=${3:-}
 
 if [[ "${COUNTRY}1" != "fr1" ]]
 then
@@ -13,6 +14,12 @@ fi
 if  [[ "${ENV}1" != "dev1" ]] && [[ "${ENV}1" != "test1" ]] && [[ "${ENV}1" != "prod1" ]]
 then
   echo "'${ENV}' the second parameter (env) is not valid. Valid values are ['dev', 'test', 'prod']"
+  exit 1
+fi
+
+if [[ -n "${COMMAND}" ]] && [[ "${COMMAND}" != "indexes" ]]
+then
+  echo "'${COMMAND}' the third parameter (command) is not valid. Valid values: 'indexes' (or omit for the standard hosting+rules deploy)"
   exit 1
 fi
 
@@ -57,6 +64,22 @@ setProject "rq-${COUNTRY}-${ENV}"
 #list current connect google account
 gcloud auth list
 
+# Indexes-only subcommand. firestore.indexes.json is the single source of
+# truth: --non-interactive --force applies all diffs (creations AND
+# deletions) without prompting. Run this after every change to
+# firestore.indexes.json, on each environment. See §12 of
+# docs/cloud-functions-endpoints.md for the index catalogue.
+if [[ "${COMMAND}" == "indexes" ]]
+then
+  echo "Deploying Firestore indexes to rq-${COUNTRY}-${ENV} (force, non-interactive)"
+  ${FIREBASE} deploy --only firestore:indexes \
+    --project "rq-${COUNTRY}-${ENV}" \
+    --non-interactive --force
+  echo "Indexes deployed to rq-${COUNTRY}-${ENV}"
+  echo "Note: new indexes go through a CREATING phase (~5-15 min) before serving queries."
+  exit 0
+fi
+
 # `firebase deploy` (no --only) pushes hosting + firestore.rules +
 # firestore.indexes. Warn explicitly when those Firestore config files have
 # uncommitted local changes, because they WILL be shipped along with hosting.
@@ -95,11 +118,11 @@ export NODE_OPTIONS=--openssl-legacy-provider
 
 # Restrict the deploy targets to hosting + firestore.rules. We deliberately
 # exclude firestore:indexes from the default deploy because firebase prompts
-# interactively to delete any server-side index that is missing from
+# interactively to delete any server-side index missing from
 # firestore.indexes.json, which both breaks unattended runs and is destructive
-# by default. Indexes are deployed explicitly with:
-#   npx firebase-tools@15 deploy --only firestore:indexes --project rq-${COUNTRY}-${ENV}
-# after reviewing the diff between the live indexes and firestore.indexes.json.
+# by default. Indexes are deployed explicitly via the dedicated subcommand:
+#   ./gcp-deploy.sh fr <env> indexes
+# See §12 of docs/cloud-functions-endpoints.md for the index catalogue.
 DEPLOY_TARGETS="hosting,firestore:rules"
 
 if [[ ${ENV} != "prod" ]]


### PR DESCRIPTION
## Context

`firestore.indexes.json` was already the source of truth but was never deployed: the standard `gcp-deploy.sh` deliberately excludes `firestore:indexes` to avoid silent destructive prompts on missing entries.

As a result, the two composite indexes on `ul_queteur_stats_per_year` required by the Cloud Functions `get-queteur-stats` and `get-ul-queteur-ranking` were absent from `rq-fr-prod`, causing a `400 The query requires an index` on the **Mon historique** page (regression introduced when those endpoints migrated to Cloud Functions v2 in #130).

## Change

Add a dedicated subcommand:

```bash
./gcp-deploy.sh fr <env> indexes
```

It runs `firebase deploy --only firestore:indexes --non-interactive --force` so the JSON file is reconciled with the server without prompting (applies creations **and** deletions). To be run after every change to `firestore.indexes.json` on each environment.

## Doc

New section 12 in `docs/cloud-functions-endpoints.md`:
- Index catalogue (each index mapped to its Cloud Function + Angular consumer)
- Deploy procedure
- Add-new-index workflow

## Deployment status

Already run on the three environments via the new subcommand. Verified `READY` state on `rq-fr-prod`:

```
NAME          FIELD_PATH                               STATE
CICAgNiroIEK  ['queteur_id', 'year', '__name__']       READY
CICAgJjFqZMK  ['ul_id', 'year', 'amount', '__name__']  READY
```

The **Mon historique** page is now functional in production.

## Scope

This PR is intentionally limited to the deployment tooling + indexes. The timezone fix (`fix/timezone-utc-iso`) is shipped separately.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author